### PR TITLE
Added status code checking to handle errors before image-size handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,7 @@ module.exports = function requestImageSize(options) {
       let imageSizeError;
       let { statusCode: code, statusMessage: msg } = res;
 
-      if(!sc.accept(res.statusCode, "2xx", "3xx")) {
-        reject({ code, msg });
-      }
+      if(!sc.accept(code, "2xx", "3xx")) reject({ code, msg });
 
       res.on('data', chunk => {
         buffer = Buffer.concat([buffer, chunk]);

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@
 
 const request = require('request');
 const imageSize = require('image-size');
+const sc = require("statuscode");
 
 module.exports = function requestImageSize(options) {
   let opts = {
@@ -34,6 +35,11 @@ module.exports = function requestImageSize(options) {
       let buffer = new Buffer([]);
       let size;
       let imageSizeError;
+      let { statusCode: code, statusMessage: msg } = res;
+
+      if(!sc.accept(res.statusCode, "2xx", "3xx")) {
+        reject({ code, msg });
+      }
 
       res.on('data', chunk => {
         buffer = Buffer.concat([buffer, chunk]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1623,14 +1623,10 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+    "statuscode": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/statuscode/-/statuscode-0.0.0.tgz",
+      "integrity": "sha1-/Skf3b0PbpJ5Qd8oo5e6aHJaU3U="
     },
     "string-width": {
       "version": "2.1.1",
@@ -1657,6 +1653,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "image-size": "^0.6.1",
-    "request": "^2.54.0"
+    "request": "^2.54.0",
+    "statuscode": "0.0.0"
   },
   "devDependencies": {
     "eslint-config-savelist": "^1.1.1"


### PR DESCRIPTION
If the request cannot be completed, a better error message should return besides `file type unsupported`