### PR TITLE
Immediately exit if error is returned…

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function requestImageSize(options) {
           size = imageSize(buffer);
         } catch (err) {
           imageSizeError = err;
-          return;
+          return req.abort();
         }
 
         if (size) {


### PR DESCRIPTION
Immediately exit if error is returned instead of waiting for the whole file to download. The most obvious case is when the url is an unsupported format (such as am `.mp4`). The `lookup` function in `imageSize` will always throw a type error, but `request-image-size` will download the whole file and check each chunk. This might be not noticeable in cases where the file is small but can be a pain when the file is larger, like the movie example.