### PR TITLE
latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint": "eslint ./"
   },
   "dependencies": {
-    "image-size": "^0.6.1",
+    "image-size": "^0.9.3",
     "request": "^2.54.0",
     "standard-http-error": "^2.0.1"
   },


### PR DESCRIPTION
Version being packages is "image-size@0.6.1"

I'm having issues with blank files not throwing error messages that seems to be resolved with newer versions of image-size.