### PR TITLE
fix: don't abort if the buffer exceeds the limits (introduced in #13)

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,10 @@ module.exports = function requestImageSize(options) {
         try {
           size = imageSize(buffer);
         } catch (err) {
-          imageSizeError = err;
-          return req.abort();
+          if (!err.message.includes('exceeded buffer limits')) {
+            imageSizeError = err;
+            return req.abort();
+          }
         }
 
         if (size) {


### PR DESCRIPTION
From #13:

> This commit is breaking the ability to detect the size for -at least- some JPG images.
When I experience this problem, I see that the first data block retrieved is something like 16K, but image-size module is trying to read ahead of that block, throwing 'Corrupt JPG, exceeded buffer limits' error.
For such an error, it is required to fetch the upcoming blocks of the image too.

This should prevent calling `abort()` in that case and continue reading